### PR TITLE
Feature/custom app scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ shiva/
 ### Drivers
 
 - **Postgres** (`shiva/drivers/databases/postgres.py`): Asyncpg-based connection pool.
-- **Redis** (`shiva/drivers/databases/redis.py`): Aioredis-based connection pool.
+- **Redis** (`shiva/drivers/databases/redis.py`): Redis (async) connection pool.
 - **MongoDB** (`shiva/drivers/databases/mongodb.py`): Motor-based async MongoDB client.
 - **S3** (`shiva/drivers/api/s3_aiobotocore.py`): Async S3 client using aiobotocore.
 
@@ -341,7 +341,7 @@ waiter_daemon:
 
 ## Dependencies
 
-- **Core**: FastAPI, Uvicorn, aiomisc, aio-pika, aioredis, asyncpg, PyYAML, orjson, loguru, sentry-sdk, flatdict, typer, art, marshmallow, motor, aiobotocore, prometheus-client, mako, starlette, fastapi-utils.
+- **Core**: FastAPI, Uvicorn, aiomisc, aio-pika, redis, asyncpg, PyYAML, orjson, loguru, sentry-sdk, flatdict, typer, art, marshmallow, motor, aiobotocore, prometheus-client, mako, starlette, fastapi-utils.
 - **Dev**: ipython (optional).
 
 ---

--- a/README.md
+++ b/README.md
@@ -273,11 +273,49 @@ workers:
 
 #### Key Parameters
 
+- **scopes** (optional): Load additional modules from installed packages
 - **common**: General settings (uvloop, coroutine count, modules path)
 - **logging**: Log level, Sentry integration
 - **connections**: Database/message broker connections (driver, DSN, pool settings)
 - **dispatchers**: Dispatcher instances (type, connection, protocol, policy, coroutines, config)
 - **workers**: Worker instances (name, coroutines, enabled, worker class, dispatcher, config, dependencies)
+
+#### Extending Shiva with Package Scopes
+
+You can extend Shiva by loading drivers, workers, dispatchers, and protocols from installed packages. This allows you to create reusable extensions.
+
+**Loading Order**: `shiva` (built-in) → `packages` (installed) → `user` (local)
+
+**Example:**
+
+```yaml
+scopes:
+  packages:
+    - my_shiva_extension
+    - another_extension
+```
+
+For a package `my_shiva_extension`, Shiva will attempt to load:
+- `my_shiva_extension.drivers`
+- `my_shiva_extension.workers`
+- `my_shiva_extension.dispatchers`
+- `my_shiva_extension.proto`
+- `my_shiva_extension.data_types`
+
+**Package Structure Example:**
+
+```
+my_shiva_extension/
+  drivers/
+    databases/
+      my_custom_db.py
+  workers/
+    my_worker.py
+  dispatchers/
+    my_dispatcher.py
+```
+
+Modules are deduplicated by file path - first found wins. Missing scopes are silently skipped.
 
 #### Example: RMQ Dispatcher Section
 

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ workers:
 
 You can extend Shiva by loading drivers, workers, dispatchers, and protocols from installed packages. This allows you to create reusable extensions.
 
-**Loading Order**: `shiva` (built-in) → `packages` (installed) → `user` (local)
+**Loading Order**: `shiva` (built-in) → `user` (local) → `packages` (installed)
 
 **Example:**
 

--- a/config.example.yml
+++ b/config.example.yml
@@ -1,5 +1,15 @@
 app_name: shiva_test
 
+# Scopes configuration (optional)
+# Load additional scopes from installed packages
+# Order: shiva -> packages -> user
+scopes:
+    packages: []
+    # Example:
+    # packages:
+    #   - my_shiva_extension
+    #   - another_package
+
 # Common settings
 common:
     uvloop: True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "shivad"
-version = "0.4.18"
+version = "0.5.0"
 description = "A modern, async Python framework for distributed systems and microservices."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,35 +9,35 @@ authors = [
 ]
 license = "MIT"
 dependencies = [
-    "aiomisc>=14.0.0,<15.0.0",
-    "aio-pika>=9.0.5,<10.0.0",
-    "aioredis>=1.3.1,<2.0.0",
-    "asyncpg>=0.28.0,<1.0.0",
-    "PyYAML>=6.0.1,<7.0.0",
-    "orjson>=3.5.2,<4.0.0",
-    "fastapi",
-    "argparse>=1.4.0,<2.0.0",
-    "uvicorn>=0.13.4,<1.0.0",
-    "loguru>=0.7.2,<1.0.0",
-    "sentry-sdk>=1.0.0,<2.0.0",
-    "flatdict>=4.0.1,<5.0.0",
-    "typer>=0.3.2,<1.0.0",
-    "art>=5.2,<6.0.0",
-    "marshmallow>=3.13.0,<4.0.0",
-    "motor>=3.6.0,<4.0.0",
     "aiobotocore>=2.16.0,<3.0.0",
-    "packaging>=23.0,<24.0",
-    "twine>=3.8.0,<4.0.0",
-    "keyring>=23.5.0,<24.0.0",
-    "uvloop>=0.17.0,<1.0.0; sys_platform == 'darwin' or sys_platform == 'linux'",
+    "aiomisc>=17.9.9,<18.0.0",
+    "aio-pika>=9.5.8,<10.0.0",
+    "argparse>=1.4.0,<2.0.0",
+    "art>=5.2,<6.0.0",
+    "asyncpg>=0.31.0,<0.32.0",
+    "fastapi>=0.124.0,<0.125.0",
     "fastapi-restful",
-    "prometheus-client>=0.18.0,<1.0.0",
-    "mako>=1.3.0,<2.0.0",
-    "starlette>=0.37.2,<1.0.0",
     "fastapi-utils[all]>=0.8.0,<1.0.0",
+    "flatdict>=4.0.1,<5.0.0",
+    "keyring>=25.0.0,<26.0.0",
+    "loguru>=0.7.2,<1.0.0",
+    "mako>=1.3.0,<2.0.0",
+    "marshmallow>=3.13.0,<4.0.0",
+    "motor>=3.7.1,<4.0.0",
+    "orjson>=3.5.2,<4.0.0",
+    "packaging>=24.0,<25.0",
+    "prometheus-client>=0.18.0,<1.0.0",
     "pytest>=8.4.1",
-    "setuptools>=80.9.0",
     "pytest-asyncio>=1.0.0",
+    "PyYAML>=6.0.1,<7.0.0",
+    "redis>=5.0.0,<6.0.0",
+    "sentry-sdk>=2.47.0,<3.0.0",
+    "setuptools>=80.9.0",
+    "starlette>=0.50.0,<0.51.0",
+    "twine>=5.0.0,<6.0.0",
+    "typer>=0.20.0,<0.21.0",
+    "uvicorn>=0.38.0,<0.39.0",
+    "uvloop>=0.21.0,<1.0.0; sys_platform == 'darwin' or sys_platform == 'linux'",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",
@@ -71,4 +71,7 @@ extend-include = ["*.ipynb"]
 license-files = ["LICENSE"]
 
 [tool.setuptools.packages.find]
-where = ["."] 
+where = ["."]
+
+[tool.pytest.ini_options]
+pythonpath = "."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,55 +3,51 @@ name = "shivad"
 version = "0.4.18"
 description = "A modern, async Python framework for distributed systems and microservices."
 readme = "README.md"
-requires-python = ">=3.11"
-authors = [
-  { name = "Boris Soldatov", email = "djsaff@gmail.com" }
-]
+requires-python = ">=3.12"
+authors = [{ name = "Boris Soldatov", email = "djsaff@gmail.com" }]
 license = "MIT"
 dependencies = [
-    "aiobotocore>=2.16.0,<3.0.0",
-    "aiomisc>=17.9.9,<18.0.0",
-    "aio-pika>=9.5.8,<10.0.0",
-    "argparse>=1.4.0,<2.0.0",
-    "art>=5.2,<6.0.0",
-    "asyncpg>=0.31.0,<0.32.0",
-    "fastapi>=0.124.0,<0.125.0",
-    "fastapi-restful",
-    "fastapi-utils[all]>=0.8.0,<1.0.0",
-    "flatdict>=4.0.1,<5.0.0",
-    "keyring>=25.0.0,<26.0.0",
-    "loguru>=0.7.2,<1.0.0",
-    "mako>=1.3.0,<2.0.0",
-    "marshmallow>=3.13.0,<4.0.0",
-    "motor>=3.7.1,<4.0.0",
-    "orjson>=3.5.2,<4.0.0",
-    "packaging>=24.0,<25.0",
-    "prometheus-client>=0.18.0,<1.0.0",
-    "pytest>=8.4.1",
-    "pytest-asyncio>=1.0.0",
-    "PyYAML>=6.0.1,<7.0.0",
-    "redis>=5.0.0,<6.0.0",
-    "sentry-sdk>=2.47.0,<3.0.0",
-    "setuptools>=80.9.0",
-    "starlette>=0.50.0,<0.51.0",
-    "twine>=5.0.0,<6.0.0",
-    "typer>=0.20.0,<0.21.0",
-    "uvicorn>=0.38.0,<0.39.0",
-    "uvloop>=0.21.0,<1.0.0; sys_platform == 'darwin' or sys_platform == 'linux'",
+  "aiobotocore>=2.16.0,<3.0.0",
+  "aiomisc>=17.9.9,<18.0.0",
+  "aio-pika>=9.5.8,<10.0.0",
+  "argparse>=1.4.0,<2.0.0",
+  "art>=5.2,<6.0.0",
+  "asyncpg>=0.31.0,<0.32.0",
+  "fastapi>=0.124.0,<0.125.0",
+  "fastapi-restful",
+  "fastapi-utils[all]>=0.8.0,<1.0.0",
+  "flatdict>=4.0.1,<5.0.0",
+  "keyring>=25.0.0,<26.0.0",
+  "loguru>=0.7.2,<1.0.0",
+  "mako>=1.3.0,<2.0.0",
+  "marshmallow>=3.13.0,<4.0.0",
+  "motor>=3.7.1,<4.0.0",
+  "orjson>=3.5.2,<4.0.0",
+  "packaging>=24.0,<25.0",
+  "prometheus-client>=0.18.0,<1.0.0",
+  "pytest>=8.4.1",
+  "pytest-asyncio>=1.0.0",
+  "PyYAML>=6.0.1,<7.0.0",
+  "redis>=5.0.0,<6.0.0",
+  "sentry-sdk>=2.47.0,<3.0.0",
+  "setuptools>=80.9.0",
+  "starlette>=0.50.0,<0.51.0",
+  "twine>=5.0.0,<6.0.0",
+  "typer>=0.20.0,<0.21.0",
+  "uvicorn>=0.38.0,<0.39.0",
+  "uvloop>=0.21.0,<1.0.0; sys_platform == 'darwin' or sys_platform == 'linux'",
 ]
 classifiers = [
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.12",
-    "Operating System :: OS Independent",
-    "Development Status :: 4 - Beta",
-    "Intended Audience :: Developers",
-    "Topic :: Software Development :: Libraries :: Application Frameworks",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.12",
+  "Operating System :: OS Independent",
+  "Development Status :: 4 - Beta",
+  "Intended Audience :: Developers",
+  "Topic :: Software Development :: Libraries :: Application Frameworks",
 ]
 
 [project.optional-dependencies]
-dev = [
-    "ipython>=8.22.1,<9.0.0"
-]
+dev = ["ipython>=8.22.1,<9.0.0"]
 
 [project.scripts]
 shiva = "shiva.shiva_cli:main"

--- a/shiva/common/cli.py
+++ b/shiva/common/cli.py
@@ -65,23 +65,23 @@ class ShivaCLI:
         logger.info("Loading shiva + packages + user scopes...")
 
         # Get additional packages from config
-        scope_packages = self.config.get('scopes', {}).get('packages', [])
+        scope_packages = self.config.get("scopes", {}).get("packages", [])
         valid_packages = self._validate_scope_packages(scope_packages)
 
         for scope in scopes:
             # Build scope loading chain
-            # Order: shiva -> packages -> user
+            # Order: shiva -> user -> packages
             sc_list = []
 
             # 1. Built-in shiva modules
             sc_list.append(f"{SHIVA_ROOT}.{scope}")
 
-            # 2. Modules from installed packages
+            # 2. User modules
+            sc_list.append(scope)
+
+            # 3. Modules from installed packages
             for package in valid_packages:
                 sc_list.append(f"{package}.{scope}")
-
-            # 3. User modules
-            sc_list.append(scope)
 
             # TODO: Current implementation loads first found module and skips duplicates.
             # If user modules need to override package modules, reverse the order.

--- a/shiva/common/daemon.py
+++ b/shiva/common/daemon.py
@@ -1,4 +1,5 @@
 import asyncio
+import importlib
 import sys
 import time
 
@@ -42,15 +43,60 @@ class Shiva:
         logger.info('Preparing dispatchers...')
         await self.droot.prepare()
 
+    def _validate_scope_packages(self, packages):
+        """
+        Validate that scope packages are installed.
+
+        Args:
+            packages: List of package names to validate
+
+        Returns:
+            List of valid package names
+        """
+        valid_packages = []
+        for package in packages:
+            try:
+                importlib.import_module(package)
+                valid_packages.append(package)
+                logger.info(f'Scope package "{package}" found')
+            except ImportError:
+                logger.warning(f'Scope package "{package}" not found, skipping')
+        return valid_packages
+
     def load_scopes(self, scopes):
-        logger.info('Loading shiva + user scopes...')
+        logger.info('Loading shiva + packages + user scopes...')
+
+        # Get additional packages from config
+        scope_packages = self.config.get('scopes', {}).get('packages', [])
+        valid_packages = self._validate_scope_packages(scope_packages)
 
         for scope in scopes:
-            sc_list = (f'{SHIVA_ROOT}.{scope}', scope)
-            logger.info(f'Loading scopes: {sc_list}')
+            # Build scope loading chain
+            # Order: shiva -> packages -> user
+            sc_list = []
+
+            # 1. Built-in shiva modules
+            sc_list.append(f'{SHIVA_ROOT}.{scope}')
+
+            # 2. Modules from installed packages
+            for package in valid_packages:
+                sc_list.append(f'{package}.{scope}')
+
+            # 3. User modules
+            sc_list.append(scope)
+
+            # TODO: Current implementation loads first found module and skips duplicates.
+            # If user modules need to override package modules, reverse the order.
+            # See: shiva/common/modules_helper.py:Scope.load()
+
+            logger.info(f'Scope "{scope}" loading order:')
+            for idx, path in enumerate(sc_list, 1):
+                logger.info(f'  {idx}. {path}')
+
             self.scopes[scope] = Scope(scope, sc_list)
+
         for name, scope in self.scopes.items():
-            logger.info(f'{name}: {len(scope.scopes)}')
+            logger.info(f'{name}: {len(scope.scopes)} modules loaded')
 
     async def wait_coro(self):
         logger.info('Coro waiter started!')


### PR DESCRIPTION
Added support for loading modules from external packages via scopes.packages configuration. Updated project dependencies.

  Changes

  - Custom scopes — cli.py and daemon.py now support loading scope modules from installed packages. Loading order: shiva (built-in) → user (local) → packages (installed). Duplicates are filtered by file path — first found wins.
  - Bump dependencies — updated dependency versions (redis instead of aioredis, fastapi, sentry-sdk, typer, uvicorn, etc.), minimum Python version raised to 3.12.
  - Docs — README updated with "Extending Shiva with Package Scopes" section covering loading order and configuration examples.
